### PR TITLE
Needs a test: Add socket status messages

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -217,7 +217,10 @@ function mockManager(managerProto, server){
 	};
 	managerProto.socket = function(){
 		debug('MockedManager.prototype.socket ...');
-		return new MockedSocket(server);
+		var socket = new MockedSocket(server);
+		socket.connected = true;
+		socket.disconnected = false;
+		return socket;
 	};
 	return origs;
 }

--- a/test/test.js
+++ b/test/test.js
@@ -42,7 +42,7 @@ QUnit.test('basic connection', function(assert){
 	assert.expect(2);
 	var socket = io('http://localhost:8080/api');
 	socket.on('connect', function(){
-		assert.ok(true, 'socket connected');
+		assert.ok(socket.connected, 'socket connected');
 	});
 	socket.on('notifications', function(data){
 		assert.deepEqual(data, {test: 'OK'}, 'received notifications message');


### PR DESCRIPTION
This adds `connected` and `disconnected` booleans to the socket object like a normal socket.io has.