### PR TITLE
Add steal paths config to fix loading @feathers/common

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,10 @@
       "generator-donejs",
       "donejs-cli",
       "steal-tools"
-    ]
+    ],
+    "paths": {
+      "@feathersjs/commons*lib/lib": "node_modules/@feathersjs/commons/lib/index.js"
+    }
   },
   "dependencies": {
     "can-fixture": "^3.0.0",


### PR DESCRIPTION
One of this project’s dependencies changed their `main` to something that isn’t compatible with steal. This adds config for steal to be able to load that package correctly. See https://github.com/stealjs/steal/issues/1507 for more info.